### PR TITLE
#!/usr/bin/env python

### DIFF
--- a/py_h264_bitc.py
+++ b/py_h264_bitc.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import subprocess
 import sys
 import os


### PR DESCRIPTION
on the top, then it works fine on Ubuntu (otherwise not).
